### PR TITLE
Release and publish release notes using GitHub Action

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -1,0 +1,52 @@
+# Copyright (C) 2023 ScyllaDB
+
+name: Releases
+
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+'
+    - 'v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
+    - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+  # GitHub actions suck for re-triggering on tag changes, so we allow also manual trigger.
+  # Also useful for easily re-triggering release notes updates when PR title is fixed.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for publishing a release, like `v1.3.0`. The old release must be deleted before this job.'
+        required: true
+
+env:
+  go_version: '1.20'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release-notes:
+    name: Publish release notes
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Determine current tag
+      run: |
+        set -euExo pipefail
+        shopt -s inherit_errexit
+        
+        if [[ -n '${{ github.event.inputs.tag }}' ]]; then
+          current_tag='${{ github.event.inputs.tag }}'
+        else
+          current_tag="${GITHUB_REF#refs/*/}"
+        fi
+        
+        echo "current_tag=${current_tag}" | tee -a ${GITHUB_ENV}
+    
+    - name: Generate and publish release notes
+      uses: scylladb/scylla-operator/.github/actions/release-notes@master
+      with:
+        githubRepository: ${{ github.repository }}
+        githubRef: ${{ env.current_tag }}
+        githubToken: ${{ secrets.GITHUB_TOKEN }}
+        goVersion: ${{ env.go_version }}
+        genReleaseNotesVersionRef: v1.8.1


### PR DESCRIPTION
Release notes are generated from PR titles merged between latest and current release.

Requirements:

- [x] https://github.com/scylladb/scylla-operator/pull/1234