### PR TITLE
Pin release notes GH Action to v1.9.0-alpha.3

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -43,10 +43,10 @@ jobs:
         echo "current_tag=${current_tag}" | tee -a ${GITHUB_ENV}
     
     - name: Generate and publish release notes
-      uses: scylladb/scylla-operator/.github/actions/release-notes@master
+      uses: scylladb/scylla-operator/.github/actions/release-notes@v1.9.0-alpha.3
       with:
         githubRepository: ${{ github.repository }}
         githubRef: ${{ env.current_tag }}
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         goVersion: ${{ env.go_version }}
-        genReleaseNotesVersionRef: v1.8.1
+        genReleaseNotesVersionRef: v1.9.0-alpha.3


### PR DESCRIPTION
Action code was taken from master and used parameter not available in v1.8.1 version of the tool.