### PR TITLE
Specify version of release notes GH Action explicitly

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -19,7 +19,6 @@ on:
 
 env:
   go_version: '1.20'
-  scylla_operator_version: 'v1.9.0-alpha.4'
 
 defaults:
   run:
@@ -44,11 +43,11 @@ jobs:
         echo "current_tag=${current_tag}" | tee -a ${GITHUB_ENV}
     
     - name: Generate and publish release notes
-      uses: scylladb/scylla-operator/.github/actions/release-notes@${{ env.scylla_operator_version }}
+      uses: scylladb/scylla-operator/.github/actions/release-notes@v1.9.0-alpha.4
       with:
         githubRepository: ${{ github.repository }}
         githubRef: ${{ env.current_tag }}
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         goVersion: ${{ env.go_version }}
-        genReleaseNotesVersionRef: ${{ env.scylla_operator_version }}
+        genReleaseNotesVersionRef: v1.9.0-alpha.4
         containerImageName: docker.io/scylladb/k8s-local-volume-provisioner


### PR DESCRIPTION
Using an env variable in `uses` is forbidden:
```
The workflow is not valid. .github/workflows/releases.yaml (Line: 47, Col: 13): Unrecognized named-value: 'env'. Located at position 1 within expression: env.scylla_operator_version
```