### PR TITLE
Remove socket file if it exists during boot

### DIFF
--- a/pkg/cmd/local-csi-driver/driver.go
+++ b/pkg/cmd/local-csi-driver/driver.go
@@ -159,6 +159,10 @@ func (o *LocalDriverOptions) run(ctx context.Context, _ genericclioptions.IOStre
 		return fmt.Errorf("can't create driver: %w", err)
 	}
 
+	if err := os.Remove(o.Listen); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("can't remove file at %q: %w", o.Listen, err)
+	}
+
 	lc := net.ListenConfig{}
 	listener, err := lc.Listen(ctx, "unix", o.Listen)
 	if err != nil {


### PR DESCRIPTION
Socket file may exist when node terminates ungracefuly. Existance of it prevented driver from booting. To overcome this, we remove it before we start listening.

Tested on VM where I was able to reproduce it 100% times when VM was powered off. Issue is no longer present with the fix.

Fixes #21 