### PR TITLE
Make sure xfs-disk-setup lands on the same nodes as local-csi-driver

### DIFF
--- a/example/disk-setup/50_daemonset.yaml
+++ b/example/disk-setup/50_daemonset.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: xfs-disk-setup
     spec:
+      tolerations:
+      - operator: Exists
       containers:
       - name: xfs-disk-setup
         image: docker.io/scylladb/k8s-local-volume-provisioner:latest


### PR DESCRIPTION
`xfs-disk-setup` and `local-csi-driver` are deployed together and must always land on the same set of nodes. This means their tolerations need to match as well or some could avoid some "dedicated" or otherwise tainted node and the other one would break.

Resolves #32 