### PR TITLE
Fix e2e to use in-cluster config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	k8s.io/api v0.28.4
 	k8s.io/apimachinery v0.28.4
 	k8s.io/apiserver v0.28.4
-	k8s.io/client-go v1.5.2
 	k8s.io/component-base v0.28.4
 	k8s.io/klog/v2 v2.110.1
 	k8s.io/kubectl v0.28.4
@@ -119,6 +118,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.28.4 // indirect
+	k8s.io/client-go v1.5.2 // indirect
 	k8s.io/cloud-provider v0.28.4 // indirect
 	k8s.io/component-helpers v0.28.4 // indirect
 	k8s.io/controller-manager v0.28.4 // indirect

--- a/pkg/cmd/tests/options.go
+++ b/pkg/cmd/tests/options.go
@@ -5,13 +5,10 @@ package tests
 import (
 	"flag"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/client-go/tools/clientcmd"
 	kubeframework "k8s.io/kubernetes/test/e2e/framework"
 	kubeframeworkconfig "k8s.io/kubernetes/test/e2e/framework/config"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
@@ -50,12 +47,6 @@ func (o *KubeFrameworkOptions) AddFlags(cmd *cobra.Command) {
 	)))
 
 	cmd.PersistentFlags().StringVarP(&kubeframework.TestContext.KubeConfig, "kubeconfig", "", kubeframework.TestContext.KubeConfig, "Path to the kubeconfig file.")
-
-	// k8s.io/kubernetes/test/e2e/framework requires env KUBECONFIG to be set
-	// it does not fall back to defaults
-	if os.Getenv(clientcmd.RecommendedConfigPathEnvVar) == "" {
-		os.Setenv(clientcmd.RecommendedConfigPathEnvVar, filepath.Join(os.Getenv("HOME"), ".kube", "config"))
-	}
 
 	kubeframeworkconfig.CopyFlags(kubeframeworkconfig.Flags, flag.CommandLine)
 	kubeframework.RegisterCommonFlags(kubeframeworkconfig.Flags)


### PR DESCRIPTION
Kubernetes test framework can use incluster config if we don't mess with the KUBECONFIG env var.

Fixes #36