### PR TITLE
Dockerfile: apt-get upgrade to get the latest packages

### DIFF
--- a/images/k8s-local-volume-provisioner/Dockerfile
+++ b/images/k8s-local-volume-provisioner/Dockerfile
@@ -8,6 +8,7 @@ FROM quay.io/scylladb/scylla-operator-images:base-ubuntu-22.04
 SHELL ["/bin/bash", "-euEo", "pipefail", "-O", "inherit_errexit", "-c"]
 
 RUN apt-get update && \
+    apt-get upgrade && \
     apt-get install -y --no-install-recommends xfsprogs && \
     apt-get clean  && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes: https://github.com/scylladb/k8s-local-volume-provisioner/issues/42