### PR TITLE
Fix NodePublishVolume and ValidateVolumeCapabilities debug logs

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -153,6 +153,8 @@ func (d *driver) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (
 }
 
 func (d *driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+	klog.V(4).InfoS("New request", "server", "controller", "function", "ValidateVolumeCapabilities", "request", protosanitizer.StripSecrets(req))
+
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "VolumeID is missing in request")

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -74,7 +74,7 @@ func (d *driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 }
 
 func (d *driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
-	klog.V(4).InfoS("New request", "server", "node", "function", "NodePublishVolume", "request", protosanitizer.StripSecrets(req))
+	klog.V(4).InfoS("New request", "server", "node", "function", "NodeUnpublishVolume", "request", protosanitizer.StripSecrets(req))
 
 	targetPath := req.GetTargetPath()
 	if len(targetPath) == 0 {


### PR DESCRIPTION
This PR fixes a wrong function name in node server's `NodePublishVolume` debug log and adds a missing one to controller server's `ValidateVolumeCapabilities`. 

/kind feature
/priority important-longterm
/cc zimnx