### PR TITLE
build(deps): bump the CSI sidecar images and manage them with Renovate

### DIFF
--- a/deploy/kubernetes/local-csi-driver/10_provisioner_clusterrole.yaml
+++ b/deploy/kubernetes/local-csi-driver/10_provisioner_clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
   - "watch"
   - "create"
   - "delete"
+  - "patch"
 - apiGroups:
   - ""
   resources:

--- a/deploy/kubernetes/local-csi-driver/50_daemonset.yaml
+++ b/deploy/kubernetes/local-csi-driver/50_daemonset.yaml
@@ -56,7 +56,7 @@ spec:
           periodSeconds: 2
           failureThreshold: 5
       - name: csi-driver-registrar
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:fdff3ee285341bc58033b6b2458a5d45fd90ec6922a8ba6ebdd49b0c41e2cd34
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0@sha256:f9de845b170155199f2a2a3f9531cf13d78e31235e9db6b6582a8b0db0a50dad
         imagePullPolicy: IfNotPresent
         args:
         - --csi-address=/csi/csi.sock
@@ -67,7 +67,7 @@ spec:
         - name: registration-dir
           mountPath: /registration
       - name: liveness-probe
-        image: registry.k8s.io/sig-storage/livenessprobe@sha256:cacee2b5c36dd59d4c7e8469c05c9e4ef53ecb2df9025fa8c10cdaf61bce62f0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0@sha256:06da0d5b8908072f2e4522692aee8dc119fba7247a9658497e1153992cd777e9
         imagePullPolicy: IfNotPresent
         args:
         - --csi-address=/csi/csi.sock
@@ -77,13 +77,12 @@ spec:
         - name: plugin-dir
           mountPath: /csi
       - name: csi-provisioner
-        image: registry.k8s.io/sig-storage/csi-provisioner@sha256:ee3b525d5b89db99da3b8eb521d9cd90cb6e9ef0fbb651e98bb37be78d36b5b8
+        image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0@sha256:bb057f866177d5f4139a1527e594499cbe0feeb67b63aaca8679dfdf0a6016f9
         imagePullPolicy: IfNotPresent
         args:
         - --csi-address=/csi/csi.sock
         - --v=2
         - --node-deployment
-        - --feature-gates=Topology=true
         - --immediate-topology=false
         - --enable-capacity
         - --capacity-ownerref-level=0

--- a/deploy/kubernetes/local-csi-driver/50_daemonset.yaml
+++ b/deploy/kubernetes/local-csi-driver/50_daemonset.yaml
@@ -56,6 +56,7 @@ spec:
           periodSeconds: 2
           failureThreshold: 5
       - name: csi-driver-registrar
+        # renovate: datasource=docker depName=csi-node-driver-registrar packageName=registry.k8s.io/sig-storage/csi-node-driver-registrar versioning=semver
         image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0@sha256:f9de845b170155199f2a2a3f9531cf13d78e31235e9db6b6582a8b0db0a50dad
         imagePullPolicy: IfNotPresent
         args:
@@ -67,6 +68,7 @@ spec:
         - name: registration-dir
           mountPath: /registration
       - name: liveness-probe
+        # renovate: datasource=docker depName=livenessprobe packageName=registry.k8s.io/sig-storage/livenessprobe versioning=semver
         image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0@sha256:06da0d5b8908072f2e4522692aee8dc119fba7247a9658497e1153992cd777e9
         imagePullPolicy: IfNotPresent
         args:
@@ -77,6 +79,7 @@ spec:
         - name: plugin-dir
           mountPath: /csi
       - name: csi-provisioner
+        # renovate: datasource=docker depName=csi-provisioner packageName=registry.k8s.io/sig-storage/csi-provisioner versioning=semver
         image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0@sha256:bb057f866177d5f4139a1527e594499cbe0feeb67b63aaca8679dfdf0a6016f9
         imagePullPolicy: IfNotPresent
         args:

--- a/renovate.json
+++ b/renovate.json
@@ -15,27 +15,41 @@
   ],
   "packageRules": [
     {
-      "description": "Dockerfile base images should be updated every weekday",
+      "description": "Container image references should be updated every weekday",
       "matchDatasources": [
         "docker"
-      ],
-      "matchFileNames": [
-        "images/**/Dockerfile"
       ],
       "schedule": [
         "before 5am every weekday"
       ]
+    },
+    {
+      "description": "csi-provisioner must stay on v5.x: v6.0.0 requires Kubernetes 1.34, above the minimum Kubernetes version supported by scylla-operator",
+      "matchDepNames": [
+        "csi-provisioner"
+      ],
+      "allowedVersions": "<6.0.0"
     }
   ],
   "customManagers": [
     {
       "description": "Custom manager for Dockerfile with Renovate annotations matching the regex.",
       "customType": "regex",
-      "fileMatch": [
-        "images/.*/Dockerfile"
+      "managerFilePatterns": [
+        "/^images/.*/Dockerfile$/"
       ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\nFROM\\s+\\S+:(?<currentValue>\\S+)"
+      ]
+    },
+    {
+      "description": "Custom manager for container image references in Kubernetes manifests with Renovate annotations matching the regex.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^deploy/kubernetes/local-csi-driver/50_daemonset\\.yaml$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?(\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*image:\\s*[^\\s:]+:(?<currentValue>[^@\"\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
       ]
     }
   ]


### PR DESCRIPTION
Updates the CSI sidecars in the local-csi-driver DaemonSet, which were pinned by digest alone and over three years stale:

- `csi-node-driver-registrar`: v2.6.3 → v2.17.0
- `livenessprobe`: v2.8.0 → v2.19.0
- `csi-provisioner`: v3.3.0 → v5.3.0

csi-provisioner stays on v5.x rather than taking v6.x. v6.0.0 requires Kubernetes 1.34+, while v5.3.0 supports 1.20+, and none of the functionality v6 adds applies to this driver. Staying on v5 keeps the wider supported Kubernetes range at no cost.

The provisioner's `ClusterRole` gains `patch` on `persistentvolumes`. csi-provisioner v5 always adds its finalizer to `PersistentVolume`s with a `Delete` reclaim policy, and there is no way to turn that off.

The image references are now annotated for Renovate so future updates are proposed automatically, with csi-provisioner capped below v6.0.0.

Part of https://github.com/scylladb/scylla-operator-release/issues/524.
Closes https://scylladb.atlassian.net/browse/OPERATOR-264