### PR TITLE
docs: update README compatibility statement and backfill the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@
 <!-- Group entries under: Highlights, Upgrade requirements, Deprecations, Features & Enhancements,
      Bug fixes, Other changes, Dependencies. Omit the sections that don't apply. -->
 
+### Highlights
+
+- Local Volume Provisioner is no longer experimental. The experimental notice has been removed from the project.
+  [#120](https://github.com/scylladb/local-csi-driver/pull/120)
+
+### Upgrade requirements
+
+- The provisioner's `ClusterRole` now requires the `patch` verb on `persistentvolumes`, needed by the
+  `HonorPVReclaimPolicy` feature that `csi-provisioner` v5 enables unconditionally. Applying the manifests shipped in
+  `deploy/kubernetes` grants it automatically; if you manage the provisioner's RBAC yourself, grant it before
+  upgrading, or provisioning will fail with a permission error.
+  [#127](https://github.com/scylladb/local-csi-driver/pull/127)
+
+### Bug fixes
+
+- Fixed volume publishing failing when the parent directories of the target path did not already exist on the node,
+  which could leave pods waiting indefinitely for their volumes to be mounted.
+  [#111](https://github.com/scylladb/local-csi-driver/pull/111)
+
+### Dependencies
+
+- The CSI sidecars were updated: `csi-node-driver-registrar` from `v2.6.3` to `v2.17.0`, `livenessprobe` from `v2.8.0`
+  to `v2.19.0` and `csi-provisioner` from `v3.3.0` to `v5.3.0`.
+  [#127](https://github.com/scylladb/local-csi-driver/pull/127)
+- Kubernetes dependencies were updated to 1.36.
+  [#124](https://github.com/scylladb/local-csi-driver/pull/124)
+- Go was updated to 1.26.
+  [#122](https://github.com/scylladb/local-csi-driver/pull/122)
+- The base image was updated to UBI 9.7.
+  [#118](https://github.com/scylladb/local-csi-driver/pull/118)
+- Kubernetes staging module versions are now resolved to exact versions, so builds no longer pick up floating patch
+  releases.
+  [#115](https://github.com/scylladb/local-csi-driver/pull/115)
+
 ## Versions released before 1.0.0
 
 For versions released before 1.0.0, the changelog information can be found in

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Please go through [CSI Spec](https://github.com/container-storage-interface/spec
 driver before you start.
 
 ### Requirements
-* Golang 1.18+
-* Kubernetes 1.24+
+* Golang 1.26+
+* Kubernetes 1.33 – 1.36
 
 ### Testing
 To execute all unit tests and e2e test suites run: `make test`


### PR DESCRIPTION
Updates the README's stated Golang and Kubernetes versions and backfills `CHANGELOG.md` with the user-facing changes made since v0.5.0.

Part of https://github.com/scylladb/scylla-operator-release/issues/524.
Closes https://scylladb.atlassian.net/browse/OPERATOR-268.