### PR TITLE
[v1.0] chore: set the local-csi-driver image tag to 1.0

### DIFF
--- a/deploy/kubernetes/local-csi-driver/50_daemonset.yaml
+++ b/deploy/kubernetes/local-csi-driver/50_daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       - name: local-csi-driver
         securityContext:
           privileged: true
-        image: docker.io/scylladb/local-csi-driver:latest
+        image: docker.io/scylladb/local-csi-driver:1.0
         imagePullPolicy: IfNotPresent
         args:
         - --listen=/csi/csi.sock

--- a/example/disk-setup/50_daemonset.yaml
+++ b/example/disk-setup/50_daemonset.yaml
@@ -18,7 +18,7 @@ spec:
       - operator: Exists
       containers:
       - name: xfs-disk-setup
-        image: docker.io/scylladb/local-csi-driver:latest
+        image: docker.io/scylladb/local-csi-driver:1.0
         imagePullPolicy: IfNotPresent
         command:
         - "/bin/bash"


### PR DESCRIPTION
Point the deployment manifests at the 1.0 release stream instead of `latest`.

Part of https://scylladb.atlassian.net/browse/OPERATOR-239